### PR TITLE
Correct font attributes for Footer

### DIFF
--- a/src/views/component/Navigation/corporate-footer/style.less
+++ b/src/views/component/Navigation/corporate-footer/style.less
@@ -154,8 +154,9 @@
         float: none;
 
         a {
-          font-family: "ScaniaSansRegular", Helvetica, Arial, sans-serif;
-          font-size: 12px;
+           font-family: "Scania Sans", Helvetica, Arial, sans-serif;
+           font-size: 14px;
+           font-weight: bold;
         }
       }
     }


### PR DESCRIPTION
Should be in the same format as in AEM (Contry Sites) and NOT as on the Scania.Com landing page.