### PR TITLE
border color fixed for table-panel

### DIFF
--- a/src/global/less/corporate-ui/custom-classes/tables.less
+++ b/src/global/less/corporate-ui/custom-classes/tables.less
@@ -167,7 +167,6 @@ table.table {
 
 .table-panel {
   background-color: white;
-  border: 1px solid;
   border-collapse: inherit;
 
   > thead {


### PR DESCRIPTION
-border for table-panel default is 1px solid #dadada
![table-panel](https://user-images.githubusercontent.com/35451568/45030338-c8a39680-b04b-11e8-92c5-cdf07bb24f6b.png)
