### PR TITLE
Labels in forms font-size changed

### DIFF
--- a/src/global/less/corporate-ui/forms.less
+++ b/src/global/less/corporate-ui/forms.less
@@ -24,6 +24,16 @@ textarea[placeholder] {
   }
 }
 
+.app {
+  .form-group {
+    label {
+      font-family: "Scania Sans Semi Condensed";
+      font-size: 1.2rem;
+      font-weight: bold;
+    }
+  }
+}
+
 .form-control {
   color: #747472;
   padding: 20px 40px;
@@ -125,16 +135,8 @@ textarea[placeholder] {
   }
 }
 
-.control-label {
-  font-family: 'Scania Sans';
-  font-weight: bold;
-  font-size: 0.9em;
-  white-space: normal;
-}
-
 .form-horizontal {
 
-  .control-label,
   .radio,
   .checkbox,
   .radio-inline,


### PR DESCRIPTION
- Labels in forms font-size changed in app
- Removed "Control-label" custom-class bootstrap
![dfadsafds](https://user-images.githubusercontent.com/35451568/45078653-d95a1800-b0f0-11e8-9c18-04be82cfc7a7.png)
