### PR TITLE
Small fixes to letter-spacing

### DIFF
--- a/src/global/less/corporate-ui/typography.less
+++ b/src/global/less/corporate-ui/typography.less
@@ -126,7 +126,7 @@ article {
   h1 {
     font-size: @h1-font-size-article;
     text-align: inherit;
-    letter-spacing: normal;
+    letter-spacing: 0.03rem;
   }
 
   h2 {
@@ -189,7 +189,6 @@ article p.lead,
 p.lead,
 .app p.lead {
   font-family: 'Scania Sans';
-  font-weight: bold;
   font-size: 1.26em;
   color: @interaction-primary;
   font-weight: normal;
@@ -200,7 +199,7 @@ address {
   font-size: 1.2rem;
 
   h4 {
-    font-family: 'Scania Sans Condensed';
+    font-family: 'Scania Sans Semi Condensed';
     font-weight: bold;
     font-size:  1.8rem;
     color: #53565A;
@@ -278,7 +277,7 @@ address {
   h1,
   h2,
   h3 {
-    letter-spacing: 0.03rem;
+    letter-spacing: normal;
     text-align: left;
   }
 


### PR DESCRIPTION
Should be normal for Semi Condensed and 0.03rem for Scania Sans Headline.