### PR TITLE
Only paragraphs within an article should have 26px line-height

### DIFF
--- a/src/global/less/corporate-ui/typography.less
+++ b/src/global/less/corporate-ui/typography.less
@@ -312,14 +312,14 @@ address {
 
   article {
     &:extend(article);
-    line-height: 26px;
-
     h2,
     h3,
     h4,
     h5,
     h6,
-    p,
+    p {
+       line-height: 26px;
+    },
     p.lead {
       font-family: "Scania Sans Semi Condensed";
     }


### PR DESCRIPTION
Not other emements that inherits for example <li> etc etc