### PR TITLE
Article paragraph inherit correct font-size

### DIFF
--- a/src/global/less/corporate-ui/typography.less
+++ b/src/global/less/corporate-ui/typography.less
@@ -312,6 +312,8 @@ address {
 
   article {
     &:extend(article);
+    font-family: 'Scania Sans Semi Condensed';
+
     h2,
     h3,
     h4,
@@ -354,8 +356,6 @@ address {
       &:extend(article h6);
     }
     p {
-      font-size: @p-font-size-app-article;
-      line-height: 26px;
       &:extend(article p);
 
       &.lead {

--- a/src/global/less/corporate-ui/variables.less
+++ b/src/global/less/corporate-ui/variables.less
@@ -46,7 +46,7 @@
 @h4-font-size-article:          2.3rem;
 @h5-font-size-article:          2rem;
 @h6-font-size-article:          1.8rem;
-@p-font-size-article:           1.8rem;
+@p-font-size-article:           1.6rem;
 @td-font-size-article:          1rem;
 
 // App Article
@@ -56,7 +56,6 @@
 @h4-font-size-app-article:      2.0rem;
 @h5-font-size-app-article:      1.8rem;
 @h6-font-size-app-article:      1.6rem;
-@p-font-size-app-article:       1.6rem;
 @p-lead-font-size-app-article:  2.0rem;
 @td-font-size-app-article:      1.6rem;
 


### PR DESCRIPTION
Article paragraph inherit correct font-size
Removed variable for paragraph in article app 