### PR TITLE
Scania Sans Semi Condensed instead of Scania Sans

### DIFF
--- a/src/global/less/corporate-ui/typography.less
+++ b/src/global/less/corporate-ui/typography.less
@@ -79,7 +79,7 @@ dt {
 dd,
 strong,
 button {
-  font-family: "Scania Sans";
+  font-family: "Scania Sans Semi Condensed";
   color: @interaction-primary;
   font-weight: bold;
 }


### PR DESCRIPTION
Replace Scania Sans font with Scania Sans Semi Condensed for the strong elements
Mock: https://preview.uxpin.com/c93b453a3bd3d1ad7ae32da7ee5dd4f67aeb608a#/pages/76066049/specification/sitemap
Printscreen: PRTSCR - Scania Sans.png
![prtscr - scania sans](https://user-images.githubusercontent.com/43435760/45805957-24168b00-bcc0-11e8-9ca4-b29f9d68a8d0.png)
