### PR TITLE
Button spacing fixes

### DIFF
--- a/src/global/less/corporate-ui/button-groups.less
+++ b/src/global/less/corporate-ui/button-groups.less
@@ -53,6 +53,13 @@
       &:extend(.btn-lg all);
     }
   }
+
+  + .btn-group,
+  + .btn {
+  margin-left: 12px;
+  float: none;
+  }
+
 }
 
 .btn-toolbar {

--- a/src/global/less/corporate-ui/button-groups.less
+++ b/src/global/less/corporate-ui/button-groups.less
@@ -56,13 +56,29 @@
 
   + .btn-group,
   + .btn {
-  margin-left: 12px;
-  float: none;
+      margin-left: 9px;
+      float: none;
+  }
+
+  + .btn + .btn,
+  + .btn + .btn-group,
+  + .btn-group + .btn,
+  + .btn-group + .btn-group {
+      margin-left: -1px;
+      float: left;
   }
 
 }
 
 .btn-toolbar {
-    margin-top: 15px;
+    font-size: 0;
     margin-bottom: 15px;
+    
+    > .btn,
+    > .btn-group,
+    > .input-group {
+        margin-left: 9px;
+  }
 }
+
+

--- a/src/global/less/corporate-ui/buttons.less
+++ b/src/global/less/corporate-ui/buttons.less
@@ -30,9 +30,15 @@
     box-shadow: none;
   }
 
-  + .btn {
-    margin-left: 15px;
+  + .btn,
+  + .btn-group {
+    margin-left: 12px;
+    float: none;
   }
+
+  , .btn ,
+
+
 
   &-default {
     .btn-mix(default);

--- a/src/global/less/corporate-ui/buttons.less
+++ b/src/global/less/corporate-ui/buttons.less
@@ -32,7 +32,7 @@
 
   + .btn,
   + .btn-group {
-    margin-left: 12px;
+    margin-left: 9px;
     float: none;
   }
 

--- a/src/global/less/corporate-ui/buttons.less
+++ b/src/global/less/corporate-ui/buttons.less
@@ -36,9 +36,6 @@
     float: none;
   }
 
-  , .btn ,
-
-
 
   &-default {
     .btn-mix(default);
@@ -161,7 +158,6 @@
 
 
 //disabled button states
-
 .btn.disabled,
 .btn[disabled],
 fieldset[disabled] .btn {

--- a/src/global/less/corporate-ui/buttons.less
+++ b/src/global/less/corporate-ui/buttons.less
@@ -104,10 +104,10 @@
 
 .btn-xs {
   font-size: 11px;
-  padding: 3px 6px;
+  padding: 3px 6px 2px;
 
   .app & {
-    padding: 1px 5px;
+    padding: 2px 8px 1px;
     font-size: @btn-font-size-xs-app;
   }
 }


### PR DESCRIPTION
The new LESS->CSS should result in this code:

.btn + .btn {
    margin-left: 9px;
}

.btn + .btn-group {
    margin-left: 9px;
}

.btn-group + .btn-group,
.btn-group + .btn {
    margin-left: 9px;
    float: none;
}

.btn-group .btn + .btn,
.btn-group .btn + .btn-group,
.btn-group .btn-group + .btn,
.btn-group .btn-group + .btn-group {
    margin-left: -1px;
    float: left;
}

.btn-toolbar {
    font-size: 0;
    margin-bottom: 15px;
}

.btn-toolbar > .btn,
.btn-toolbar > .btn-group,
.btn-toolbar > .input-group {
    margin-left: 9px;
}