### PR TITLE
Expand collapse in main-nav on mobile

### DIFF
--- a/src/components/main-navigation/style.less
+++ b/src/components/main-navigation/style.less
@@ -28,16 +28,11 @@
     primary-items,
     secondary-items {
       
-      > nav-item {
-        display: flex;
-        flex-direction: column;
-
-        > a {
-          // Fixes issue where content could overflow its container.
-          // Making a horizontal scrollbar get displayed when a
-          // secondary navigation is available
-          overflow: hidden;
-        }
+      > nav-item > a {
+        // Fixes issue where content could overflow its container.
+        // Making a horizontal scrollbar get displayed when a
+        // secondary navigation is available
+        overflow: hidden;
       }
     }
 
@@ -280,6 +275,14 @@
               padding: 0;
             }
           }
+        }
+      }
+      primary-items,
+      secondary-items {
+        
+        > nav-item {
+          display: flex;
+          flex-direction: column;
         }
       }
 

--- a/src/components/main-navigation/style.less
+++ b/src/components/main-navigation/style.less
@@ -28,11 +28,16 @@
     primary-items,
     secondary-items {
       
-      > nav-item > a {
-        // Fixes issue where content could overflow its container.
-        // Making a horizontal scrollbar get displayed when a
-        // secondary navigation is available
-        overflow: hidden;
+      > nav-item {
+        display: flex;
+        flex-direction: column;
+
+        > a {
+          // Fixes issue where content could overflow its container.
+          // Making a horizontal scrollbar get displayed when a
+          // secondary navigation is available
+          overflow: hidden;
+        }
       }
     }
 

--- a/src/components/navbar/nav-item/style.less
+++ b/src/components/navbar/nav-item/style.less
@@ -191,7 +191,9 @@
           display: inline-block;
           content: "+";
           font-size: medium;
-          padding: 10px 15px;
+          padding: 8px 0;
+          // We use width instead of padding to make + and - align the same
+          width: 40px;
         }
       }
     }
@@ -201,6 +203,9 @@
       sub-navigation,
       .dropdown-menu {
         display: none;
+        // We have order here to make sure sub-nav is always displayed 
+        // as the last item, even though its rendered above the link
+        order: 1;
       }
     }
     &.expanded ::content {
@@ -220,13 +225,12 @@
           font-family: @subLevelFont;
           text-transform: none;
         }
+      }
 
-        + .mode-toggler,
-        + template + .mode-toggler {
+      .mode-toggler {
 
-          &:before {
-            content: "-";
-          }
+        &:before {
+          content: "-";
         }
       }
     }


### PR DESCRIPTION
- Fix for sub-nav and link alignment order incorrect when using html content making sub-nav get rendered above link in mobile mode
- Vertical alignment of exapnd and collapse in main-nav on mobile
- Fix for collapse icon not displayed in certain scenarios