### PR TITLE
Sub-nav is not getting rendered in main-nav

### DIFF
--- a/src/components/navbar/nav-item/script.ts
+++ b/src/components/navbar/nav-item/script.ts
@@ -45,8 +45,7 @@ Polymer({
       observer: 'setActive'
     },
     dropdown: {
-      type: Boolean,
-      value: false
+      type: Boolean
     }
   },
   listeners: {
@@ -87,6 +86,8 @@ Polymer({
     }
   },
   attached: function() {
+    this.dropdown = !!this.dropdown;
+
     if( this.hasClass(this, 'active') ) {
       this.toggleExpand(this._getEvent());
     }


### PR DESCRIPTION
- Changed so that dropdown param in nav-item is set on attatched event instead of pre setting it forcing the template to re render

**Note - this bug could not be reproduced using the polymer version from npm but only the polymer version picked from static...**