### PR TITLE
Corporate-footer copyright text not being correctly styled in APP

### DIFF
--- a/src/components/corporate-footer/style.less
+++ b/src/components/corporate-footer/style.less
@@ -73,24 +73,11 @@
 
 :host-context(.app) {
 
-  footer {
-    padding: 20px 30px 25px;
-  }
-
-  .wordmark {
-    width: 125px;
-    height: 21px;
-  }
-
   ::content {
 
     .footer-links {
         margin: 0 0 10px 0;
       }
-
-    .footer-copy-text {
-      padding: 0;
-    }
   }
 }
 


### PR DESCRIPTION
**Describe pull-request**</br>
- Corporate-footer copyright text not being correctly styled in APP
- Remove app related css, padding,width and height

