### PR TITLE
Fixed so that site-name is centered in the corporate header below 992px

### DIFF
--- a/src/global/less/corporate-ui/navigation.less
+++ b/src/global/less/corporate-ui/navigation.less
@@ -631,6 +631,7 @@
           width: 40px;
           height: 37px;
           margin: -5px;
+          margin-left: 12px;          
 
           &:before {
             position: static;


### PR DESCRIPTION
Problem is that site-name is centering over a to big area. Problem:

Site name aligned to the left:

![image](https://user-images.githubusercontent.com/10209902/48968362-bb64cb00-efee-11e8-903a-b981e95b1d64.png)

Site name aligned to the right:
![image](https://user-images.githubusercontent.com/10209902/48968373-e4855b80-efee-11e8-8d53-3f9d7f7ddd32.png)
