### PR TITLE
Small fixes for help-block and cookie message.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ testem.log
 #System Files
 .DS_Store
 Thumbs.db
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corporate-ui",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "<h1>The Corporate UI Framework</h1>\r <p>In this repository you'll find all components described in <a href=\"https://www.scania.com/ux-library/developer\">the UX Library</a>.</p>\r <p>The repository is a place for all Front End Developers to join the UI Developement at Scania. It is us togheter that develop and maintain this repository.</p> \r <ul>\r \t<li>Something broken in a existing component? Help fixing it!</li>\r \t<li>Found a component that needs to be extended? Get on and improve it!</li>\r \t<li>Missing out on a component? Develop it!</li>\r </ul>",
   "main": "gulpfile.js",
   "dependencies": {

--- a/src/components/cookie-message/style.less
+++ b/src/components/cookie-message/style.less
@@ -25,9 +25,9 @@
     } 
 
     .btn {
-      margin: 5px 5px 5px 7px;
-      margin-left: ;
       display: inline-block;
+      margin: 2px 0px 0 8px;
+      padding: 10px 18px;
     }
   }
 
@@ -44,8 +44,9 @@
 
       .text-cookie {
         font-size: 1.4rem;
-        padding: 15px;
+        padding: 0 0 10px 0;
         width: 100%;
+
       }
 
       .btn {

--- a/src/components/cookie-message/style.less
+++ b/src/components/cookie-message/style.less
@@ -1,6 +1,6 @@
 :host {
   background-color: #1d1d1d;
-  color: #FFF;
+  color: #fff;
   font-family: "Scania Sans Semi Condensed";
   font-size: 1.7rem;
 
@@ -12,6 +12,13 @@
   bottom: 0px;
 
   z-index: 1500;
+
+  a, 
+  a:hover, 
+  a:active {
+    color: inherit;
+    font-weight: bold;
+  }
 
   .text-cookie {
     display:inline-block;
@@ -26,5 +33,4 @@
   .modal {
     color: #535353;
   }
-
-};
+}

--- a/src/components/cookie-message/style.less
+++ b/src/components/cookie-message/style.less
@@ -1,36 +1,59 @@
 :host {
-  background-color: #1d1d1d;
-  color: #fff;
-  font-family: "Scania Sans Semi Condensed";
-  font-size: 1.7rem;
 
-  padding: 26px 30px 26px 30px;
-  height: auto;
-  width: 100%;
+  .cookie-short-message {
+    background-color: #1d1d1d;
+    color: #fff;
+    font-family: "Scania Sans Semi Condensed";
+    font-size: 1.7rem;
+    padding: 26px 30px 26px 30px;
+    height: auto;
+    width: 100%;
+    position: fixed;
+    bottom: 0px;
+    z-index: 1500;
 
-  position: fixed;
-  bottom: 0px;
+    a, 
+    a:hover, 
+    a:active {
+      color: inherit;
+      font-weight: bold;
+    }
 
-  z-index: 1500;
+    .text-cookie {
+      display:inline-block;
+      width: 70%;
+    } 
 
-  a, 
-  a:hover, 
-  a:active {
-    color: inherit;
-    font-weight: bold;
-  }
-
-  .text-cookie {
-    display:inline-block;
-    width: 70%;
-  }
-
-  .close-cookie {
-    margin: 5px;
-    display: inline-block;
+    .btn {
+      margin: 5px 5px 5px 7px;
+      margin-left: ;
+      display: inline-block;
+    }
   }
 
   .modal {
     color: #535353;
+  }
+}
+
+  @media (max-width: 991px) {
+    
+  :host {
+
+    .cookie-short-message {
+
+      .text-cookie {
+        font-size: 1.4rem;
+        padding: 15px;
+        width: 100%;
+      }
+
+      .btn {
+        margin: 15px 0px 4px 15px;
+        padding: 6px 18px;
+        margin-left: 7px;
+        width: 100%;
+      }
+    }  
   }
 }

--- a/src/components/cookie-message/style.less
+++ b/src/components/cookie-message/style.less
@@ -49,9 +49,8 @@
       }
 
       .btn {
-        margin: 15px 0px 4px 15px;
+        margin: 12px 0px 0 5px;
         padding: 6px 18px;
-        margin-left: 7px;
         width: 100%;
       }
     }  

--- a/src/components/cookie-message/template.html
+++ b/src/components/cookie-message/template.html
@@ -24,7 +24,7 @@
 </div>
 
 <div id="cookieAgreement" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel" aria-hidden="true">
-  <div class="modal-dialog modal-xl ">
+  <div class="modal-dialog modal-xl scroll-y">
     <div class="modal-content">
       <div class="modal-header">
         <div class="modal-title">

--- a/src/components/cookie-message/template.html
+++ b/src/components/cookie-message/template.html
@@ -1,26 +1,26 @@
-<div>
+<div class="cookie-message">
   <span class="text-cookie">
     <template is="dom-if" if="{{_langSupport(lang, 'en-gb')}}">
-      Scania uses cookies on our websites in order to ensure the performance and user experience. If you continue to browse without changing your web browser cookie settings, you are agreeing to our use of cookies. Find out more by reading our cookie guidelines in the footer link. English <!-- {{text}} -->
-      <a href="#" data-toggle="modal" data-target="#cookieAgreement"> Read More</a>
+      Scania uses cookies on our websites in order to ensure the performance and user experience. If you continue to browse without changing your web browser cookie settings, you are agreeing to our use of cookies. <!-- {{text}} -->
     </template>
     <template is="dom-if" if="{{_langSupport(lang, 'se')}}">
       När du visar den här webbplatsen eller någon annan webbplats som länkas från den här webbplatsen kan vi spara lite information på din dator i form av en ”cookie”. 
-      Scania använder bland annat cookies för att registrera besökarstatistik och för att låta användaren välja språk när han eller hon söker efter ett begagnat fordon på vår webbplats.
+      Vi använder bland annat cookies för att registrera besökarstatistik och för att låta användaren välja språk när han eller hon söker efter ett information på vår webbplats.<br/><br/>
 
-      Du kan ställa in datorn på att blockera cookies. Det innebär dock att vi inte kan garantera att alla delar av webbplatsen fungerar som de ska. Hur du blockerar cookies beror på vilken webbläsare du använder. Välj ”Hjälp” eller en motsvarande meny i webbläsaren om du behöver anvisningar. <!-- {{text}} -->
+      Du kan ställa in datorn på att blockera cookies. Det innebär dock att vi inte kan garantera att alla delar av webbplatsen fungerar som de ska. Hur du blockerar cookies beror på vilken webbläsare du använder. Välj ”Hjälp” eller en motsvarande meny i webbläsaren om du behöver anvisningar.<!-- {{text}} -->
       <a href="#" data-toggle="modal" data-target="#cookieAgreement"> Läs mer</a>
     </template>
     <template is="dom-if" if="{{_langSupport(lang, 'de')}}">
-       Scania verwendet Cookies, um Ihnen ein besseres Nutzererlebnis zu bieten. Durch Nutzung dieser Website stimmen Sie unserer Verwendung von Cookies zu. Weitere Informationen hierzu finden Sie in der <!-- {{text}} -->
+       Scania verwendet Cookies, um Ihnen ein besseres Nutzererlebnis zu bieten. Durch Nutzung dieser Website stimmen Sie unserer Verwendung von Cookies zu. Weitere Informationen hierzu finden Sie in der.<!-- {{text}} -->
       <a href="#" data-toggle="modal" data-target="#cookieAgreement">Weiterlesen</a>
     </template>
     <template is="dom-if" if="{{_langSupport(lang, 'es')}}">
-      Esta página web y otras relacionadas pueden almacenar algunos datos sobre su equipo en forma de “cookie”, lo que nos permite adaptar nuestras páginas web a sus intereses y preferencias. Al navegar en esta página está aceptando nuestra política de cookies. Spanish <!-- {{text}} -->
+      Esta página web y otras relacionadas pueden almacenar algunos datos sobre su equipo en forma de “cookie”, lo que nos permite adaptar nuestras páginas web a sus intereses y preferencias. Al navegar en esta página está aceptando nuestra política de cookies.<!-- {{text}} -->
       <a href="#" data-toggle="modal" data-target="#cookieAgreement">Lee mas</a>
     </template>
   </span>
-  <span class="close-cookie pull-right btn btn-transparent" >Accept</span>
+  <span class="btn btn-transparent pull-right" data-toggle="modal" data-target="#cookieAgreement">Learn more</span>  
+  <span class="btn btn-transparent close-cookie pull-right">Accept</span>
 </div>
 
 <div id="cookieAgreement" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="myLargeModalLabel" aria-hidden="true">
@@ -32,7 +32,7 @@
           Cookies
         </div>
       </div>
-      <div class="modal-body scroll-y">
+      <div class="modal-body">
         <article>
         <template is="dom-if" if="{{_langSupport(lang, 'en-gb')}}">
           <p>Our website uses cookies. Below, you will find further information on these cookies; what they are, what cookies we use, what our purpose is for using them, and how you go about blocking or deleting cookies.</p>

--- a/src/components/cookie-message/template.html
+++ b/src/components/cookie-message/template.html
@@ -1,4 +1,4 @@
-<div class="cookie-message">
+<div class="cookie-short-message">
   <span class="text-cookie">
     <template is="dom-if" if="{{_langSupport(lang, 'en-gb')}}">
       Scania uses cookies on our websites in order to ensure the performance and user experience. If you continue to browse without changing your web browser cookie settings, you are agreeing to our use of cookies. <!-- {{text}} -->

--- a/src/global/less/corporate-ui/forms.less
+++ b/src/global/less/corporate-ui/forms.less
@@ -296,12 +296,19 @@ select {
 
 }
 
+span.help-block,
+.app span.help-block,
 p.help-block,
 .app p.help-block  {
     font-size: 1.2rem;
     color: @main-font-color;
     line-height: normal;
 }
+
+span.help-block,
+.app span.help-block {
+    display: inline;
+}   
 
 .has-info .help-block {
     border-left: 4px solid @interaction-info;

--- a/src/global/ts/core.ts
+++ b/src/global/ts/core.ts
@@ -275,7 +275,7 @@ function baseComponents(references) {
 }
 
 function appendExternals() {
-  window['preLoadedComponents'] = ['corporate-header', 'corporate-footer', 'main-navigation'];
+  window['preLoadedComponents'] = ['corporate-header', 'corporate-footer', 'main-navigation', 'cookie-message', 'fullscreen', 'main-hero' ];
 
   // Adds support for webcomponents if non exist
   if (!('import' in document.createElement('link'))) {


### PR DESCRIPTION
As a designer you sometimes want the help-block to stretch 100% (user p  class="help-block") under the input field and sometimes you want it to just be as wide as the help text in querstion, then use span class="help-block"