### PR TITLE
Added styling for :focus and :active states in Corporate Footer

### DIFF
--- a/src/components/corporate-footer/style.less
+++ b/src/components/corporate-footer/style.less
@@ -60,6 +60,17 @@
         }
       }
     }
+
+    .dropdown-menu > .active > a,
+    .dropdown-menu > .active > a:focus {
+        text-decoration: none;
+        background-color: transparent;
+    }
+    .dropdown-menu > .active > a:hover{
+    text-decoration: underline;
+      background-color: transparent;
+    }
+
   }
 }
 
@@ -171,6 +182,11 @@
           margin: 0;
           box-shadow: none;
           text-align: center;
+          > .active > a,
+          > .active > a:hover,
+          > .active > a:focus{
+            color:  #1d1d1d;
+          }
         }
       }
       .footer-links {


### PR DESCRIPTION
**Describe pull-request**</br>
Active link in c-corporate-footer has blue background inherited from bootstrap. This pull request removed the blue background and maintain corporate UI styling on active links.

**Browser tested**<br/>
- [x ] Chrome
- [x ] Firefox
- [x ] Internet Explorer

 **Describe how to test it**</br>
Add more nav-item links in the footer. Check on active state 
<nav-item location="#" class="active">Link Text</nav-item>
