### PR TITLE
Added panel-xs back in for toasts.

### DIFF
--- a/src/global/less/corporate-ui/panels-wells.less
+++ b/src/global/less/corporate-ui/panels-wells.less
@@ -88,6 +88,28 @@
     }
   }
 
+  
+  .panel-xs {
+    font-family: "Scania Sans Semi Condensed";
+    border-radius: 2px;
+    box-shadow: 0px 0px 8px rgba(0,0,0,0.16);
+
+      .panel-heading,
+      .panel-heading .panel-title {
+        font-family: "Scania Sans Semi Condensed";
+        font-weight: bold;
+        font-size: 1.2rem;
+        padding: 3px 6px 2px;
+      }
+
+      .panel-body {
+        font-weight: normal;
+        font-size: 1.4rem;
+        padding: 10px 20px 10px 10px;
+        line-height: 2.2rem;
+    }
+  }   
+
 
   .app & {
 
@@ -148,6 +170,8 @@
 .panel-danger {
   .panel-mixin(danger);
 }
+
+
 
 //panel groups (accordion)
 


### PR DESCRIPTION
The .panel-xs styling seem to really haven't been implemented due to confusion with FMP toasts. Here they are again!