### PR TITLE
Fixed font size and made icon size depending on parent size.

### DIFF
--- a/src/global/less/corporate-ui/custom-classes/buttons.less
+++ b/src/global/less/corporate-ui/custom-classes/buttons.less
@@ -46,7 +46,7 @@
   .btn-link.btn-info {
     font-weight: bold;
     text-decoration: none;
-    color: @btn-info-bg;
+    color: @interaction-info;
     background-color: transparent;
     border-color: transparent;
 
@@ -60,27 +60,9 @@
     }
 
     i {
-      font-size: 1.6rem;
+      font-size: 1.2em;
       padding-right: 3px;
       vertical-align: text-top;
-    }
-  }
-
-  .btn-lg.btn-link.btn-info i {
-    font-size: 1.9rem;
-    padding-right: 5px;
-    vertical-align: top;
-  }
-
-  .panel-footer  {
-    .btn-link.btn-info {
-        font-size: 1.2rem;
-
-    i {
-        font-size: 1.6rem;
-        padding-right: 5px;
-        vertical-align: text-bottom;
-      }
     }
   }
 }


### PR DESCRIPTION
When an icon is placed within a link with both .btn-link AND .btn-info classes, it should be 1.2em bigger than the link itself. This is a rare coding example and used pretty much by Corporate UI only.

Note: This type of link is used for being a Button in special cases, when NO Underline hover effect is desired. If one only want a link with info color, one would use other means of achiving that.