### PR TITLE
Bootstrap triggers does not work in FF 64

### DIFF
--- a/src/components/corporate-header/script.ts
+++ b/src/components/corporate-header/script.ts
@@ -29,7 +29,8 @@ Polymer({
     },
     hasMainNav: {
       type: Boolean,
-      value: false
+      value: false,
+      observer: 'initHamburger'
     },
     sticky: {
       type: String
@@ -70,6 +71,18 @@ Polymer({
 
     if ((this.dealerName || this.dealerLogo) && this.dealerUrl) {
       this.dealer = ' is-dealer';
+    }
+  },
+  initHamburger: function(state) {
+    // Special handling for Firefox 64 if application is using requirejs
+    if (state && !window['Collapse']) {
+      this.async(function() {
+        var button = this.querySelector('button')
+        button.onclick = function() {
+          document.querySelector('#main-navigation').classList.toggle('in');
+          document.body.classList.toggle('navigation-open')
+        }
+      });
     }
   }
 });

--- a/src/components/main-navigation/script.ts
+++ b/src/components/main-navigation/script.ts
@@ -117,6 +117,10 @@ Polymer({
 
     // Set start collapse value - couldnt get this to work in a better way...
     // this.querySelector('.navbar-toggle').classList.add('collapsed');
+
+    // Special handling for Firefox 64 if application is using requirejs
+    /* Handle all dom click events related to c-main-navigation */
+    document.onclick = this.documentOnClick;
   },
   ready: function() {
     this.unwrap(this.getContentChildren('#primary-items')[0]);
@@ -387,5 +391,14 @@ Polymer({
     if (a.index > b.index) order = 1;
 
     return order;
+  },
+  documentOnClick: function (event) {
+    var navItems = this.querySelectorAll('nav-item > a');
+    for (var i = 0; i < navItems.length; i ++ ) {
+      if (!navItems[i].isEqualNode(event.target) &&
+        navItems[i].parentElement.classList.contains('open')) {
+        navItems[i].parentElement.classList.remove('open');
+      }
+    }
   }
 });

--- a/src/components/navbar/nav-item/script.ts
+++ b/src/components/navbar/nav-item/script.ts
@@ -83,7 +83,16 @@ Polymer({
 
       if(this.items && this.dropdown) {
         a.classList.add('dropdown-toggle');
-        a.setAttribute('data-toggle', 'dropdown');
+
+        if (window['Dropdown']) {
+          a.setAttribute('data-toggle', 'dropdown');
+        } else {
+          // Special handling for Firefox 64 if application is using requirejs
+          a.onclick = function(event) {
+            event.preventDefault();
+            a.parentElement.classList.toggle('open');
+          }
+        }
       }
     }
   },


### PR DESCRIPTION
- When requirejs is used and rendered in firefox 64 the bootstrap-native lib is not rendered, this change will simply trigger classes in that case