### PR TITLE
Fix code-sample duplicate item in ie

### DIFF
--- a/src/components/code-sample/code-sample.scss
+++ b/src/components/code-sample/code-sample.scss
@@ -2,10 +2,11 @@
 
 :host {
   display: block;
+}
 
-  .slot {
-    display: none;
-  }
+::slotted(*:not(pre)) {
+  // We have important here because slotted rules have lowest prio
+  display: none !important;
 }
 
 pre,

--- a/src/components/code-sample/code-sample.tsx
+++ b/src/components/code-sample/code-sample.tsx
@@ -2,7 +2,11 @@ import {
   Component, h, Prop, State, Element,
 } from '@stencil/core';
 
-import hljs from 'highlight.js';
+// import hljs from 'highlight.js';
+import hljs from 'highlight.js/lib/highlight';
+import js from 'highlight.js/lib/languages/javascript';
+import xml from 'highlight.js/lib/languages/xml';
+import css from 'highlight.js/lib/languages/css';
 
 @Component({
   tag: 'c-code-sample',
@@ -17,8 +21,10 @@ export class Field {
   @Element() el: HTMLElement;
 
   componentWillLoad() {
-    const parsed = this.el.innerHTML.replace(/"/g, "'")
-      .replace(/&quot;/g, '"');
+    const parsed = this.el.innerHTML
+      .replace(/"/g, "'")
+      .replace(/&quot;/g, '"')
+      .replace(/<!---->/g, "");
 
     if (!document.head.attachShadow) {
       hljs.configure({
@@ -27,17 +33,19 @@ export class Field {
       });
     }
 
+    hljs.registerLanguage('js', js);
+    hljs.registerLanguage('html', xml);
+    hljs.registerLanguage('css', css);
+
     this.code = hljs.highlight(this.type, parsed, false).value;
   }
 
   render() {
     return [
-      // need to keep render the slot to make it easy to hide it in IE
-      <div class='slot'><slot/></div>,
+      <slot />,
       <pre>
-        <code class={this.type} { ... { innerHTML: this.code } }>
-        </code>
-      </pre>,
+        <code class={this.type} { ... { innerHTML: this.code } }></code>
+      </pre>
     ];
   }
 }


### PR DESCRIPTION
**Describe pull-request**  
- Fix for duplicate item in IE
- Removed empty comment rendering in IE
- Optimization for highlight.js lib

**Solving issue**  
_Add which issue this pull-request solves by adding # plus the number of the issue (for example #123)_
Fixes: #506 scania/corporate-ui-site#14

**How to test**  
Open component library and then:
- Navigation to a webcomponent in ie
- Navigate to a example and expand code example in IE (You will see a rendered component in the code box)