### PR TITLE
Fix FoUC visibility style order

### DIFF
--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -35,7 +35,7 @@ function fixFouc() {
   const elm = document.createElement('style');
   const style = document.createTextNode('body { visibility: hidden; }');
 
-  document.head.appendChild(elm);
+  document.head.insertBefore(elm, document.head.firstChild);
   elm.appendChild(style);
 
   document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
- Body visibility visible order is not correct in react & vue, it is now fixed by appending visibility hidden to the top of the nodes.

**How to test**  
- Test in react, vue, and angular

