### PR TITLE
Add theme version info

### DIFF
--- a/src/components/theme/theme.tsx
+++ b/src/components/theme/theme.tsx
@@ -79,6 +79,9 @@ export class Theme {
   }
 
   render() {
+    if(this.currentTheme['version']!==undefined) {
+      document.documentElement.setAttribute(`${this.name}-theme-version`, `${this.currentTheme['version']}`);
+    }
     if (this.favicons && this.favicons) {
       this.renderFavicon();
     }


### PR DESCRIPTION
- Added theme version to html attribute
- It will fetch version info from theme data {version: xxx }

**Solving issue**  
_Add which issue this pull-request solves by adding # plus the number of the issue (for example #123)_
Fixes: https://github.com/scania/scania-theme/issues/95

**How to test**  
1. Test together with https://github.com/scania/scania-theme/pull/142
2. Check html attribute, both in CDN & NPM ways

**Screenshots**  
_If applicable, add screenshots to help explain_
![image](https://user-images.githubusercontent.com/1199101/81059903-b7bac080-8ed1-11ea-8c27-911db9c347e4.png)


**Additional context**  
_Add any other context about the pull-request here._
