### PR TITLE
Bug- fallback colour for IE added in code-example

### DIFF
--- a/src/components/code-sample/code-sample.scss
+++ b/src/components/code-sample/code-sample.scss
@@ -15,10 +15,12 @@ pre {
   padding: 40px;
   background-color: var(--black);
   background-color: #2D2926; //FIXME: Fallback for IE
+  color: #FAFAFA; //Fallback for IE, due to highligh.js not working
 }
 
 pre,
 pre code {
+  font-size: 1.3rem;
   white-space: pre-wrap;
   margin: 0;
 }

--- a/src/components/code-sample/code-sample.tsx
+++ b/src/components/code-sample/code-sample.tsx
@@ -3,6 +3,7 @@ import {
 } from '@stencil/core';
 
 // import hljs from 'highlight.js';
+// Highlight JS is not supported in IE 11, fallback provided in the code-sample.scss
 import hljs from 'highlight.js/lib/highlight';
 import js from 'highlight.js/lib/languages/javascript';
 import xml from 'highlight.js/lib/languages/xml';


### PR DESCRIPTION
**Describe pull-request**  
_Describe what the pull-request is about_
- Removes the clutter text above the component in IE 
- Fixes the code-example colour with a fallback solution
- Fixes the font-size in FF  

**Solving issue**  
_Add which issue this pull-request solves by adding # plus the number of the issue (for example #123)_
Fixes: #557 

**How to test**  
_Add description how to test if possible_
1. Use this branch with scania/corporate-ui-site#70
2. Look at the code examples for component in IE and Chrome for compare

**Screenshots**  
_If applicable, add screenshots to help explain_
![image](https://user-images.githubusercontent.com/35451568/81167344-5a884300-8f95-11ea-9cb8-ba094f32cec7.png)

Additonal: 
One more PR related to this in scania/corporate-ui-site#70

