### PR TITLE
Improvement - adapted stylesheet for c-table

### DIFF
--- a/src/components/dropdown/dropdown.scss
+++ b/src/components/dropdown/dropdown.scss
@@ -1,0 +1,19 @@
+// Required
+@import 'node_modules/bootstrap/scss/functions';
+@import 'node_modules/bootstrap/scss/variables';
+@import 'node_modules/bootstrap/scss/mixins';
+
+// Optional
+@import 'node_modules/bootstrap/scss/reboot';
+@import 'node_modules/bootstrap/scss/dropdown';
+@import 'node_modules/bootstrap/scss/buttons';
+
+:host {
+  .dropdown{
+    @extend .dropdown;
+  }
+}
+slot[name=dropdown-item],
+::slotted([slot=dropdown-item]) {
+  cursor: pointer;
+}

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -1,0 +1,115 @@
+import {
+  Component, h, Prop, State, Element, Watch, Host, Listen
+} from '@stencil/core';
+
+import BsDropdown from 'bootstrap/js/src/dropdown';
+import { themeStyle } from '../../helpers/themeStyle';
+
+@Component({
+  tag: 'c-dropdown',
+  styleUrl: 'dropdown.scss',
+  shadow: true,
+})
+export class Dropdown {
+  @Prop({ context: 'store' }) ContextStore: any;
+
+  /** Per default, this will inherit the value from c-theme name property */
+  @Prop({ mutable: true }) theme: string;
+
+  /** Button interaction pattern for dropdown */
+  @Prop() buttonType: string = "primary";
+
+  /** Dropdown direction: dropup, dropright, dropleft */
+  @Prop() direction: string;
+
+  /** Custom dropdown menu alignment: dropdown-menu-right */
+  @Prop() menuAlignment: string;
+
+  @State() store: any;
+
+  @State() tagName: string;
+
+  @State() currentTheme = { components: [] };
+
+  @State() style: Array<CSSStyleSheet>;
+
+  @State() items: Array<any> = [];
+
+  @State() dropdown;
+
+  @Element() el;
+
+  @State() node: HTMLElement;
+
+  @Listen('click', { target: 'window' })
+  handleClick(ev) {
+    const target = ev ? ev.composedPath()[0] : window.event.target[0];
+
+    if(this.node === target) {
+      const status = this.el.classList.contains('active') ? 'active' : 'inactive';
+      this.toggle(status);
+    } else {
+      this.toggle('active');
+    }    
+  }
+
+  @Watch('theme')
+  setTheme(name = undefined) {
+    this.theme = name || this.store.getState().theme.current;
+    this.currentTheme = this.store.getState().theme.items[this.theme];
+  }
+
+  toggle(status){
+    if(status === 'active') {
+      this.dropdown.hide();
+      this.el.classList.remove('active')
+    } else {
+      this.dropdown.show();
+      this.el.classList.add('active')
+    }
+  }
+
+  componentWillLoad() {
+    this.store = this.ContextStore || (window as any).CorporateUi.store;
+
+    this.setTheme(this.theme);
+
+    this.store.subscribe(() => {
+      this.setTheme();
+      
+      themeStyle(this.currentTheme, this.tagName, this.style, this.el);
+    });
+
+    if (!(this.el && this.el.nodeName)) return;
+
+    this.tagName = this.el.nodeName.toLowerCase();
+  }
+
+  componentDidLoad() {
+    this.style = this.el.shadowRoot.adoptedStyleSheets || [];
+    
+    themeStyle(this.currentTheme, this.tagName, this.style, this.el);
+    this.dropdown = new BsDropdown(this.node);
+  }
+
+  render() {
+    return (
+      <Host>
+        <div class={`
+          dropdown
+          ${this.direction ? this.direction : ''}
+        `}>
+          <button class={`btn btn-${this.buttonType} dropdown-toggle`} type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" onClick={(ev)=>this.handleClick(ev)} ref={(node) => this.node = node}>
+            <slot name="dropdown-title"></slot>
+          </button>
+          <div class={`
+            dropdown-menu
+            ${this.menuAlignment ? this.menuAlignment : ''}
+          `}>
+            <slot name="dropdown-item" />
+          </div>
+        </div>
+      </Host>
+    )
+  }
+}

--- a/src/components/dropdown/dropdown.tsx
+++ b/src/components/dropdown/dropdown.tsx
@@ -45,7 +45,7 @@ export class Dropdown {
   handleClick(ev) {
     const target = ev ? ev.composedPath()[0] : window.event.target[0];
 
-    if(this.node === target) {
+    if(this.node === target || target.getAttribute('slot') === 'dropdown-title') {
       const status = this.el.classList.contains('active') ? 'active' : 'inactive';
       this.toggle(status);
     } else {
@@ -99,8 +99,15 @@ export class Dropdown {
           dropdown
           ${this.direction ? this.direction : ''}
         `}>
-          <button class={`btn btn-${this.buttonType} dropdown-toggle`} type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" onClick={(ev)=>this.handleClick(ev)} ref={(node) => this.node = node}>
-            <slot name="dropdown-title"></slot>
+          <button 
+          class={`btn btn-${this.buttonType} dropdown-toggle`} 
+          type="button" id="dropdownMenuButton" 
+          data-toggle="dropdown" 
+          aria-haspopup="true" 
+          aria-expanded="false" 
+          onClick={(ev)=>this.handleClick(ev)} 
+          ref={(node) => this.node = node}>
+            <slot name="dropdown-title" data-toggle="dropdown"></slot>
           </button>
           <div class={`
             dropdown-menu

--- a/src/components/table/table.scss
+++ b/src/components/table/table.scss
@@ -1,12 +1,44 @@
+// Required
+@import 'node_modules/bootstrap/scss/functions';
+@import 'node_modules/bootstrap/scss/variables';
+@import 'node_modules/bootstrap/scss/mixins';
+@import 'node_modules/bootstrap/scss/transitions';
+
+// Optional
+@import 'node_modules/bootstrap/scss/tables';
+@import 'node_modules/bootstrap/scss/forms';
+@import 'node_modules/bootstrap/scss/dropdown';
+
 :host {
-    display: block;
+  display: block;
+  .table-title {
+    display: flex;
+    flex-flow: row wrap;
+    align-items: center;
+    margin-bottom: 1rem;
+    > div:first-child {
+      padding-right: 1rem;
+    }
+    > div:nth-child(2) {
+      display: flex;
+      flex-direction: column;
+      div {
+        display: flex;
+      }
+    }
   }
+
+  .input-field {
+    display: flex;
+    position: relative;
+  }
+
   .input-icon-filter {
     background: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNCIgaGVpZ2h0PSIxNCIgdmlld0JveD0iMCAwIDE0IDE0Ij48ZGVmcz48c3R5bGU+LmF7ZmlsbDojOTc5OTliO308L3N0eWxlPjwvZGVmcz48cGF0aCBjbGFzcz0iYSIgZD0iTTEzLjEyNCwwSC44NzZBLjg3Ni44NzYsMCwwLDAsLjI1NywxLjQ5NEw1LjI1LDYuNDg3djUuMTA2YS44NzUuODc1LDAsMCwwLC4zLjY1OUw3LjMsMTMuNzgzYS44NzUuODc1LDAsMCwwLDEuNDUxLS42NThWNi40ODdsNC45OTMtNC45OTRBLjg3Ni44NzYsMCwwLDAsMTMuMTI0LDBaTTcuODc1LDYuMTI1djdsLTEuNzUtMS41MzFWNi4xMjVMLjg3NS44NzVoMTIuMjVaIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgwKSIvPjwvc3ZnPg==") no-repeat !important;
     background-position: center !important;
     position: absolute;
-      top: 7px;
-      right: 18px;
+    top: 7px;
+    right: 18px;
     width: 25px;
     height: 25px;
   }
@@ -20,13 +52,12 @@
     width: 23px;
       height: 23px;
   }
-  
-  .input-field {
-    position: relative;
-  }
+
   .dropdown-menu a {
     cursor: pointer !important;
   }
   .form-control {
     padding-right: 25px !important;
   }
+}
+  

--- a/src/components/table/table.scss
+++ b/src/components/table/table.scss
@@ -52,10 +52,6 @@
     width: 23px;
       height: 23px;
   }
-
-  .dropdown-menu a {
-    cursor: pointer !important;
-  }
   .form-control {
     padding-right: 25px !important;
   }

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -73,7 +73,6 @@ export class TableComponent {
     this.style = this.el.shadowRoot['adoptedStyleSheets'] || [];
     
     themeStyle(this.currentTheme, this.tagName, this.style, this.el)
-    console.log(1, this.style);
   }
 
   /* Filter the content that will show on the table */
@@ -142,7 +141,7 @@ export class TableComponent {
 
     for (const key of keys) {
       const inputId = "search" + key;
-      let inputValue = ((this.el.shadowRoot || this.el).getElementById(inputId) as HTMLInputElement).value;
+      let inputValue = ((this.el.shadowRoot || this.el).querySelector('#'+inputId) as HTMLInputElement).value;
       
       if(inputValue)
       {
@@ -222,17 +221,11 @@ export class TableComponent {
   private setDropDown(rowIndex: number): HTMLElement {
     if(this.hasEdit || this.hasDelete)
       return <td class="text-right">
-        <div class="dropdown">
-          <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            Action
-          </button>
-          <div class='dropdown-menu dropdown-menu-right'>
-            { this.hasEdit && <a class="dropdown-item" onClick={ () => this.callbackDropdown("edit", rowIndex) }>Edit</a> }
-            { this.hasEdit && this.hasDelete? <div class="dropdown-divider"></div> : "" }
-            { this.hasDelete && <a class="dropdown-item text-danger" onClick={ () => this.callbackDropdown("delete", rowIndex) }>Delete</a> }
-
-          </div>
-        </div>
+        <c-dropdown buttonType="primary" menuAlignment="dropdown-menu-right">
+          <span slot="dropdown-title">Action</span>          
+          { this.hasEdit && <a slot="dropdown-item" class="dropdown-item" onClick={ () => this.callbackDropdown("edit", rowIndex) }>Edit</a> }
+          { this.hasDelete && <a slot="dropdown-item" class="dropdown-item text-danger" onClick={ () => this.callbackDropdown("delete", rowIndex) }>Delete</a> }
+        </c-dropdown>
       </td>
   }
   

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -1,9 +1,11 @@
-import { Component, Prop, h, State, Watch, Event, EventEmitter } from '@stencil/core';
+import { Component, Prop, h, State, Watch, Event, EventEmitter, Element } from '@stencil/core';
 import { Header } from './table.model';
+import { themeStyle } from '../../helpers/themeStyle';
 
 @Component({
   tag: 'c-table',
-  styleUrl: 'table.scss'
+  styleUrl: 'table.scss',
+  shadow: true
 })
 export class TableComponent {
   /* Array that is responsible to set which data will show on the table */
@@ -25,9 +27,23 @@ export class TableComponent {
   @State() filteredData = [];
   @State() isArray = true;
 
+  @Prop({ context: 'store' }) ContextStore: any;
+  @State() store: any;
+  @State() tagName: string;
+  @State() theme: string;
+  @State() currentTheme = { icons: { }, components: [] };
+  @State() style: Array<CSSStyleSheet>;
+  @Element() el: any;
+
   @Watch('content')
   onChangeContent() {
     this.filterContent();
+  }
+
+  @Watch('theme')
+  setTheme(name = undefined) {
+    this.theme = name || this.store.getState().theme.current;
+    this.currentTheme = this.store.getState().theme.items[this.theme];
   }
 
   componentWillLoad() {
@@ -37,6 +53,27 @@ export class TableComponent {
     }
 
     this.filterContent();
+
+    this.store = this.ContextStore || (window as any).CorporateUi.store;
+    this.theme = this.store.getState().theme.current;
+    this.currentTheme = this.store.getState().theme[this.theme];
+
+    this.store.subscribe(() => {
+      this.setTheme();
+
+      themeStyle(this.currentTheme, this.tagName, this.style, this.el);
+    });
+
+    if (!(this.el && this.el.nodeName)) return;
+
+    this.tagName = this.el.nodeName.toLowerCase();
+  }
+
+  componentDidLoad() {
+    this.style = this.el.shadowRoot['adoptedStyleSheets'] || [];
+    
+    themeStyle(this.currentTheme, this.tagName, this.style, this.el)
+    console.log(1, this.style);
   }
 
   /* Filter the content that will show on the table */
@@ -69,7 +106,7 @@ export class TableComponent {
     /* Needs to reset the Prop to make the changes */
     this.filteredData = [...this.filteredData];
 
-    const input = document.getElementById(direction + key);
+    const input = (this.el.shadowRoot || this.el).querySelector('#' + direction + key);
 
     /* If clicks on an active button, just remove the active */
     if(input.classList.contains("sort-active")) {
@@ -86,7 +123,7 @@ export class TableComponent {
     }
     
     /* Disable other sort-active class and set the active the current selected */
-    let actives = document.querySelectorAll(".sort-active");
+    let actives = (this.el.shadowRoot || this.el).querySelectorAll(".sort-active");
     [].forEach.call(actives, function(active) {
       active.classList.remove("sort-active");
     });
@@ -105,7 +142,7 @@ export class TableComponent {
 
     for (const key of keys) {
       const inputId = "search" + key;
-      let inputValue = (document.getElementById(inputId) as HTMLInputElement).value;
+      let inputValue = ((this.el.shadowRoot || this.el).getElementById(inputId) as HTMLInputElement).value;
       
       if(inputValue)
       {
@@ -144,26 +181,20 @@ export class TableComponent {
     return <tr>
       { (this.header.map((a) =>
         <th>
-          <div class="col-lg-12">
-            <div class="row">
-              <div class="d-flex pr-5 bd-highlight">
-              <p class="mt-1">{a.description}</p>
+          <div class="table-title">
+            <div>{a.description}</div>
+            <div>
+              <div onClick={() => this.sortData(a.key, "desc")}>
+                <c-icon class="sort-desc" id={"desc" + a.key} name="scania-angle-down"></c-icon>
               </div>
-              <div>
-                <div class="row" onClick={() => this.sortData(a.key, "desc")}>
-                  <c-icon class="sort-desc" id={"desc" + a.key} name="scania-angle-down"></c-icon>
-                </div>
-                <div class="row" onClick={() => this.sortData(a.key, "asc")}>
-                  <c-icon class="sort-asc" id={"asc" + a.key} name="scania-angle-down"></c-icon>
-                </div>
+              <div onClick={() => this.sortData(a.key, "asc")}>
+                <c-icon class="sort-asc" id={"asc" + a.key} name="scania-angle-down"></c-icon>
               </div>
             </div>
-            <div class="row">
-              <div class="input-field col-md-12 pl-0">
-                <input id={"search" + a.key} onKeyUp={() => this.searchColumn()} type="text" class="form-control" />
-                <div id={"icon" + a.key} class="input-icon-filter"></div>
-              </div>
-            </div>
+          </div>
+          <div class="input-field">
+            <input id={"search" + a.key} onKeyUp={() => this.searchColumn()} type="text" class="form-control" />
+            <div id={"icon" + a.key} class="input-icon-filter"></div>
           </div>
         </th>
     ))}
@@ -191,7 +222,7 @@ export class TableComponent {
   private setDropDown(rowIndex: number): HTMLElement {
     if(this.hasEdit || this.hasDelete)
       return <td class="text-right">
-        <div class="btn-group">
+        <div class="dropdown">
           <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             Action
           </button>


### PR DESCRIPTION
**Describe pull-request**  
- Implement shadow Dom for c-table component
- Under shadowDom, dropdown will not inherit bootstrap js and style from global, so it needs to be made as its own component

**Solving issue**  
Fixes: #551 

**How to test**  

Test together with https://github.com/scania/scania-theme/pull/146

Use component:

```js
<c-table></c-table>

<script>

const arr = [
      {
        "id":1,
        "name" : "Harru",
        "lastname": "Haru",
        "email": "haru@ka.com"
      },
      {
        "id":2,
        "name" : "Johan",
        "lastname": "Johansson",
        "email": "johan@asdf.com"
      },
      {
        "id":3,
        "name" : "Mika",
        "lastname": "Fedora",
        "email": "asasa@eee.com"
      },
        
    ]
    
    const el = document.querySelector('c-table');

    el.header = [
      {
        key: "name",
        description: "First Name",
      },
      {
        key: "lastname",
        description: "Last Name",
      },
      {
        key: "email",
        description: "Email",
      }
    ]
    el.content = arr;

    el.hasEdit = true;
    el.hasDelete = true;
    el.addEventListener('optEdit', testEdit)
    el.addEventListener('optDelete', testDelete)

    function testEdit(msg) {
      alert(JSON.stringify(msg.detail));
    }

    function testDelete(msg) {
    // es6 format won't work in IE
       let newArr = [...el.content];
       newArr.forEach(function(item, index){
         if(item.id == msg.detail.id) {
           newArr.splice(index, 1)
         }
       })
       el.content = newArr;
    }
</script>
```

**Screenshots**  
_If applicable, add screenshots to help explain_

**Additional context**  
_Add any other context about the pull-request here._
