### PR TITLE
Issue-568: Use protocol and host to generate static_root

### DIFF
--- a/src/global/ts/core.ts
+++ b/src/global/ts/core.ts
@@ -137,7 +137,7 @@ function setGlobals() {
   window['cui_path'] = helpers.urlInfo(scriptUrl).href.substring(0, helpers.urlInfo(scriptUrl).href.lastIndexOf('/')+1);
 
   window['corporate_ui_params'] = helpers.urlInfo(scriptUrl).search.substring(1);
-  window['static_root'] = (wv.props ? JSON.parse(wv.props)['--root'] : undefined) || helpers.urlInfo(scriptUrl).origin;
+  window['static_root'] = (wv.props ? JSON.parse(wv.props)['--root'] : undefined) || helpers.urlInfo(scriptUrl).protocol + '//' + helpers.urlInfo(scriptUrl).host;
   window['version_root'] = (window['static_root'] + helpers.urlInfo(scriptUrl).pathname).replace('/js/corporate-ui.js', '');
   window['protocol'] = helpers.urlInfo(scriptUrl).protocol;
   window['environment'] = helpers.urlInfo(scriptUrl).pathname.split('/')[1];


### PR DESCRIPTION
 - When using IE 11 the 'origin' attribute provided by the helpers script
   returns undefined. Chaining 'protocol' + '//' + 'host' results in a
   working static_root with IE 11

**Describe pull-request**  
This pull requests consists of a one-line change to how the static_root is set if wv.props does not contain the desired value. The helper script, which is the fallback if the value is missing from wv.props, returns an attribute called origin. This attribute for some reason is undefined when using IE 11. Chaining the protocol + '//' + host attributes instead provides an equivalent value to origin.


**Solving issue**  
_Add which issue this pull-request solves by adding # plus the number of the issue (for example #123)_
Fixes: #568

**How to test**  
The solution to this issue is only testable from one of the member of the ciam team's machines. We have tested the login page locally after the fix was applied with the following browsers with positive results
* Chromium
* Firefox
* Edge
* IE 11

**Screenshots**  

**Additional context**  

