### PR TITLE
Fixes #573 - Nested object properties in c-table

### DIFF
--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -81,12 +81,12 @@ export class TableComponent {
     var keys = Object.keys({...this.content[0]});
 
     /* needs clone the array this way to no mutate the content Prop */
-    this.data = this.content.map((item) => Object.assign({}, item));
+    this.data = this.content.map((item) => Object.assign({}, this.flattenObject(item)));
     
     keys = keys.filter(function(val) {
       return props.indexOf(val) == -1;
     });
-    
+
     for (const key of keys) { 
       this.data.forEach(function(v){ delete v[key] });
     }
@@ -105,7 +105,7 @@ export class TableComponent {
     /* Needs to reset the Prop to make the changes */
     this.filteredData = [...this.filteredData];
 
-    const input = (this.el.shadowRoot || this.el).querySelector('#' + direction + key);
+    const input = (this.el.shadowRoot || this.el).getElementById(direction + key);
 
     /* If clicks on an active button, just remove the active */
     if(input.classList.contains("sort-active")) {
@@ -141,7 +141,7 @@ export class TableComponent {
 
     for (const key of keys) {
       const inputId = "search" + key;
-      let inputValue = ((this.el.shadowRoot || this.el).querySelector('#'+inputId) as HTMLInputElement).value;
+      let inputValue = ((this.el.shadowRoot || this.el).getElementById(inputId) as HTMLInputElement).value;
       
       if(inputValue)
       {
@@ -240,6 +240,29 @@ export class TableComponent {
     if(event === "delete")
       this.optDelete.emit(obj);
   }
+
+  /* Flatten objects in order to match it's keys by path */
+  /* Eg: { "address": { "city": "Sydney" } } becomes { "address.city": "Sydney" }*/
+  private flattenObject(obj) {
+    let toReturn = {};
+
+    for (var i in obj) {
+      if (!obj.hasOwnProperty(i)) continue;
+
+      if ((typeof obj[i]) == 'object' && obj[i] !== null) {
+        var flatObject = this.flattenObject(obj[i]);
+        for (var x in flatObject) {
+          if (!flatObject.hasOwnProperty(x)) continue;
+
+          toReturn[i + '.' + x] = flatObject[x];
+        }
+      } else {
+        toReturn[i] = obj[i];
+      }
+    }
+    return toReturn;
+  }
+
   
   //
 


### PR DESCRIPTION
**Describe pull-request**  
Flattens objects to be able to fetch nested properties by path and display/filter/sort in c-table, by accessing it like, for example, `object['address.city']`

**Solving issue**  
Fixes: #573

**How to test**  
See #573 

**Screenshots**  
See #573 

**Additional context**  
See #573 
