### PR TITLE
Added setTheme function in willLoad

### DIFF
--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -57,6 +57,7 @@ export class TableComponent {
     this.store = this.ContextStore || (window as any).CorporateUi.store;
     this.theme = this.store.getState().theme.current;
     this.currentTheme = this.store.getState().theme[this.theme];
+    this.setTheme(this.theme);
 
     this.store.subscribe(() => {
       this.setTheme();


### PR DESCRIPTION
- It will make sure to load the theme before element is rendered in the view (didLoad)
- Somehow in Angular 10, the theme is not fetched from store in willLoad stage, cause it to cause error when component is rendered it cannot get correct theme styling

**Solving issue**  
Fixes: #577 

**How to test**  
- Test in Angular 9 or 10 setup
