### PR TITLE
Fix flash of unstyled content in CDN

### DIFF
--- a/src/helpers/cdn.js
+++ b/src/helpers/cdn.js
@@ -11,5 +11,28 @@
   scriptElm = doc.createElement('script');
   scriptElm.src = url + '/corporate-ui.js';
 
+  fixFouc();
   doc.head.insertBefore(scriptElm, parentScript[0]);
 })(document);
+
+function fixFouc() {
+  console.log('fouc')
+  var elm = document.createElement('style');
+  var style = document.createTextNode('body { visibility: hidden; }');
+
+  document.head.insertBefore(elm, document.head.firstChild);
+  elm.appendChild(style);
+
+  document.addEventListener('DOMContentLoaded', function () {
+    // This timeout is to make sure that IE has time to load
+    setTimeout(function () {
+      if (document.querySelector('c-theme')) return;
+
+      // Used in case a theme element is not rendered
+      style.nodeValue = 'body { visibility: visible; }';
+    });
+  });
+}
+
+
+

--- a/src/helpers/cdn.js
+++ b/src/helpers/cdn.js
@@ -16,7 +16,6 @@
 })(document);
 
 function fixFouc() {
-  console.log('fouc')
   var elm = document.createElement('style');
   var style = document.createTextNode('body { visibility: hidden; }');
 


### PR DESCRIPTION
- added function to hide body before c-theme loaded

**Solving issue**  
Fixes: #542 

**How to test**  
1. Setup Simple HTML Project
2. Link to this branch
3. refresh and hard refresh and see if FOUC still happens


**Additional context**  
Improvement could be made:
- FOUC scripts are now duplicated from helpers/index.js, should be provided in one place and use by both solution. But keep in mind that CDN way is different. Scripts are loaded from the browser, so, could not use import in CDN way.
