### PR TITLE
Bug - Footer styling in FF, changing theme cause error with icons and html attribute 

### DIFF
--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -28,13 +28,23 @@ export class Icon {
   @Element() el: any;
 
   @Watch('theme')
-  setTheme() {
-    this.theme = this.store.getState().theme.current;
+  setTheme(name = undefined) {
+    this.theme = name || this.store.getState().theme.current;
+    this.currentTheme = this.store.getState().theme.items[this.theme];
+
+    // If no theme is used then we return;
+    if(!name) return;
+    // Only setIcons when there is a theme
     this.setIcon();
   }
 
   @Watch('name')
   setIcon(name = this.name) {
+
+    if(!this.store.getState().theme.items[this.theme]) {
+      console.warn('No icons in this packages');
+      return;
+    }
     const items = this.store.getState().theme.items[this.theme].icons;
 
     // TODO: We should have the default icon being a simple
@@ -46,8 +56,6 @@ export class Icon {
     this.store = this.ContextStore || (window as any).CorporateUi.store;
     this.theme = this.store.getState().theme.current;
     this.currentTheme = this.store.getState().theme[this.theme];
-
-    this.setIcon();
 
     this.store.subscribe(() => {
       this.theme = this.store.getState().theme.current;
@@ -69,8 +77,8 @@ export class Icon {
 
   render() {
     return [
-      <svg xmlns='http://www.w3.org/2000/svg' viewBox={`0 0 ${this.icon.width} ${this.icon.height}`}>
-        <path fill='currentColor' d={this.icon.definition} />
+      <svg xmlns='http://www.w3.org/2000/svg' viewBox={`0 0 ${this.icon ? this.icon.width : '0'} ${this.icon ? this.icon.height : '0'}`}>
+        <path fill='currentColor' d={this.icon ? this.icon.definition : ''} />
       </svg>,
     ];
   }

--- a/src/components/theme/theme.tsx
+++ b/src/components/theme/theme.tsx
@@ -79,10 +79,13 @@ export class Theme {
   }
 
   render() {
-    if(this.currentTheme['version']!==undefined) {
-      document.documentElement.setAttribute(`${this.name}-theme-version`, `${this.currentTheme['version']}`);
+    if(this.currentTheme!==undefined && this.currentTheme['version']!==undefined) {
+      document.documentElement.setAttribute(`theme`, `${this.name}-theme v${this.currentTheme['version']}`);
+    } else {
+      document.documentElement.setAttribute(`theme`,'-')
     }
-    if (this.favicons && this.favicons) {
+
+    if (this.favicons) {
       this.renderFavicon();
     }
 

--- a/src/helpers/themeStyle.ts
+++ b/src/helpers/themeStyle.ts
@@ -1,16 +1,26 @@
 export function themeStyle(currentTheme, tagName, styleThis, el) {
-  const css = currentTheme ? currentTheme.components[tagName] : '';
+  /*
+    Helper function that will appened a stylesheet with scoped styling for specific component
+    either in the shadowRoot with adoptedStyleSheet API
+    or with a fallback method (IE,Old edge and so on)
+  */
+
   let style;
+  const css = currentTheme ? currentTheme.components[tagName] : '';
 
-  if(!styleThis) return;
+  // Fallback for currentTheme, initially empty or the currentTheme doesn't contain a version property
+  if(!currentTheme || !currentTheme.version || !styleThis) {
+    return;
+  }
 
-  // This is used by browsers with support for shadowdom
+  // If the browser has support for adoptedStyleSheet (Chromium)
   if(el.shadowRoot.adoptedStyleSheets) {
     style = new CSSStyleSheet();
     style.replaceSync(css);
     // TODO: We should not take first index we should all except the previous style
     el.shadowRoot.adoptedStyleSheets = [ el.shadowRoot.adoptedStyleSheets[0], style ];
   } else {
+    // Fallback for browsers without adoptedStyleSheet API suppport
     const node = el.shadowRoot || el;
     style = el.querySelector('#themeStyle') || document.createElement('style');
     // style.appendChild(document.createTextNode(css));
@@ -26,5 +36,7 @@ export function themeStyle(currentTheme, tagName, styleThis, el) {
     if(!node.querySelector('#themeStyle')) {
       node.insertBefore(style, node.firstChild.nextSibling);
     }
+
   }
+
 }


### PR DESCRIPTION
**Describe pull-request**  
_Describe what the pull-request is about_

- Added fallback for themes without version in the attribute on the HTML element('scania-theme: 1.1.1'), causing the error in console when switching from scania-theme or starting without a theme.
- Added fallback support for themes without icon packages, even with a another theme
- Solves issue with footer in VUE not appending correct styling in FireFox. It set the styling as undenfied in inside the style tag in the footer component.
- Change the scania-theme attribute, to show which theme and 

**Solving issue**  
_Add which issue this pull-request solves by adding # plus the number of the issue (for example #123)_
Fixes: #582 fixes: #583 

**How to test**  
_Add description how to test if possible_
1. Start a vue application for example our example in FF
2. Look at the styling of the footer
3. Try it all browser(new and old edge, FF...) 

Seconding fix
1. Start up the sdds application, try it all browser
2. Switch theme between both no theme and for example MAN
3. No error should be shown now, just a warning if there is no icons using another theme

**Screenshots**  
_If applicable, add screenshots to help explain_

**Additional context**  
_Add any other context about the pull-request here._
