### PR TITLE
Bug with dot in nested data for c-table

### DIFF
--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -297,7 +297,7 @@ export class TableComponent {
   }
 
   /* Flatten objects in order to match it's keys by path */
-  /* Eg: { "address": { "city": "Sydney" } } becomes { "address.city": "Sydney" }*/
+  /* Eg: { "address": { "city": "Sydney" } } becomes { "address-city": "Sydney" }*/
   private flattenObject(obj) {
     let toReturn = {};
 
@@ -309,7 +309,7 @@ export class TableComponent {
         for (var x in flatObject) {
           if (!flatObject.hasOwnProperty(x)) continue;
 
-          toReturn[i + '.' + x] = flatObject[x];
+          toReturn[i + '-' + x] = flatObject[x];
         }
       } else {
         toReturn[i] = obj[i];


### PR DESCRIPTION
- Use dash instead dot to avoid error in elements search & filter, need to update flatten nested data function
