### PR TITLE
Fixing display issues for the navbar within c-header

### DIFF
--- a/src/components/header/header.scss
+++ b/src/components/header/header.scss
@@ -16,6 +16,10 @@ c-navigation {
   width: 100%;
 }
 
+.navbar {
+  overflow: inherit;
+}
+
 .navbar-toggler-icon {
   background-image: $navbar-light-toggler-icon-bg;
 }

--- a/src/components/navigation/navigation.scss
+++ b/src/components/navigation/navigation.scss
@@ -33,6 +33,7 @@
 }
 
 .navbar {
+  overflow: inherit;
 
   .navbar-nav {
 
@@ -63,6 +64,7 @@
   }
 
   .navbar {
+    overflow: inherit;
 
     &.vertical {
       flex-direction: column;

--- a/src/components/navigation/navigation.scss
+++ b/src/components/navigation/navigation.scss
@@ -33,7 +33,6 @@
 }
 
 .navbar {
-  overflow: inherit;
 
   .navbar-nav {
 
@@ -64,7 +63,6 @@
   }
 
   .navbar {
-    overflow: inherit;
 
     &.vertical {
       flex-direction: column;


### PR DESCRIPTION
Adding overflow: inherit; to be able to show the content withing the dropdown inside the navbar for c-header

**Solving issue**  
This should solve the issue [Bug - "Content in dropdowns in <c-header> is hidden within the navbar"]

Fixes: #599 